### PR TITLE
Add standalone PBX middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Dialer Modal for Ethiopia
 
+### SIP Middleware
+
+The `SipMiddleware` module provides a simple wrapper around the PBX HTTP API so
+projects can interact with the SIP server without relying on Frappe. It can
+fetch connection details, manage queue membership and retrieve call logs.
+
+Basic usage inside this app:
+
+```python
+from vulero_dialer import PBXConfig, SipMiddleware
+
+config = PBXConfig(organization_id="ORG", api_key="API_KEY")
+client = SipMiddleware(config)
+```
+
+### Standalone Usage
+
+To integrate with any technology stack, copy the `pbx_middleware` package or
+install this repository as a dependency and import from `pbx_middleware`:
+
+```python
+from pbx_middleware import PBXConfig, SipMiddleware
+
+client = SipMiddleware(PBXConfig("ORG", "API_KEY"))
+info = client.get_connection_details("1001")
+```
 
 #### License
 

--- a/pbx_middleware/__init__.py
+++ b/pbx_middleware/__init__.py
@@ -1,0 +1,91 @@
+"""Lightweight client for the PBX HTTP API.
+
+This module exposes :class:`PBXConfig` and :class:`SipMiddleware` so projects
+outside the original Frappe application can integrate with the SIP server.
+Only the ``requests`` dependency is required.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+import requests
+
+
+@dataclass
+class PBXConfig:
+    """Configuration for PBX API access."""
+    organization_id: str
+    api_key: str
+    base_url: str = "https://etw-pbx-cloud1.websprix.com/api/v2"
+
+
+class SipMiddleware:
+    """Simple middleware for interacting with the PBX API."""
+
+    def __init__(self, config: PBXConfig):
+        self.config = config
+
+    def _headers(self) -> Dict[str, str]:
+        return {"x-api-key": self.config.api_key}
+
+    def get_connection_details(self, extension: str) -> Dict[str, Any]:
+        """Fetch SIP connection details for the given extension."""
+        url = (
+            f"{self.config.base_url}/onboard//get_ip_info/"
+            f"{self.config.organization_id}/{extension}/1"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def add_to_queue(self, queue_name: str, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = f"{self.config.base_url}/member/{self.config.organization_id}/add"
+        payload = {"queue_name": queue_name, "interface": interface}
+        response = requests.post(url, json=payload, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def remove_from_queue(self, queue_name: str, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = f"{self.config.base_url}/member/{self.config.organization_id}/remove"
+        payload = {"queue_name": queue_name, "interface": interface}
+        response = requests.delete(url, json=payload, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def get_queue_status(self, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = (
+            f"{self.config.base_url}/member/{self.config.organization_id}/"
+            f"queues_for_agent?interface={interface}"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_call_logs(self, extension: str, direction: str = "in") -> Dict[str, Any]:
+        url = (
+            f"{self.config.base_url}/cust_ext/{self.config.organization_id}/"
+            f"call_logs/{extension}?dir={direction}"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_offhour_callers(self, queue_name: str) -> Dict[str, Any]:
+        url = (
+            f"{self.config.base_url}/new-report/{self.config.organization_id}/"
+            f"{queue_name}/off-hour-callers?page=1&per_page=100"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_users_for_transfer(self) -> Dict[str, Any]:
+        url = f"{self.config.base_url}/cust_ext/{self.config.organization_id}/cust"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+
+__all__ = ["PBXConfig", "SipMiddleware"]

--- a/vulero_dialer/__init__.py
+++ b/vulero_dialer/__init__.py
@@ -1,1 +1,8 @@
 __version__ = "0.0.1"
+
+from .sip_middleware import PBXConfig, SipMiddleware
+
+__all__ = [
+    "PBXConfig",
+    "SipMiddleware",
+]

--- a/vulero_dialer/sip_middleware.py
+++ b/vulero_dialer/sip_middleware.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+import requests
+
+
+@dataclass
+class PBXConfig:
+    """Configuration for PBX API access."""
+    organization_id: str
+    api_key: str
+    base_url: str = "https://etw-pbx-cloud1.websprix.com/api/v2"
+
+
+class SipMiddleware:
+    """Simple middleware for interacting with the PBX API."""
+
+    def __init__(self, config: PBXConfig):
+        self.config = config
+
+    def _headers(self) -> Dict[str, str]:
+        return {"x-api-key": self.config.api_key}
+
+    def get_connection_details(self, extension: str) -> Dict[str, Any]:
+        """Fetch SIP connection details for the given extension."""
+        url = (
+            f"{self.config.base_url}/onboard//get_ip_info/"
+            f"{self.config.organization_id}/{extension}/1"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def add_to_queue(self, queue_name: str, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = f"{self.config.base_url}/member/{self.config.organization_id}/add"
+        payload = {"queue_name": queue_name, "interface": interface}
+        response = requests.post(url, json=payload, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def remove_from_queue(self, queue_name: str, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = f"{self.config.base_url}/member/{self.config.organization_id}/remove"
+        payload = {"queue_name": queue_name, "interface": interface}
+        response = requests.delete(url, json=payload, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def get_queue_status(self, extension: str) -> Dict[str, Any]:
+        interface = f"{self.config.organization_id}S{extension}"
+        url = (
+            f"{self.config.base_url}/member/{self.config.organization_id}/"
+            f"queues_for_agent?interface={interface}"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_call_logs(self, extension: str, direction: str = "in") -> Dict[str, Any]:
+        url = (
+            f"{self.config.base_url}/cust_ext/{self.config.organization_id}/"
+            f"call_logs/{extension}?dir={direction}"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_offhour_callers(self, queue_name: str) -> Dict[str, Any]:
+        url = (
+            f"{self.config.base_url}/new-report/{self.config.organization_id}/"
+            f"{queue_name}/off-hour-callers?page=1&per_page=100"
+        )
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_users_for_transfer(self) -> Dict[str, Any]:
+        url = f"{self.config.base_url}/cust_ext/{self.config.organization_id}/cust"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
## Summary
- add reusable `pbx_middleware` package independent of the Frappe app
- document standalone usage of the middleware in the README

## Testing
- `python -m py_compile pbx_middleware/__init__.py vulero_dialer/sip_middleware.py vulero_dialer/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*